### PR TITLE
Prevent caching of date in constructor

### DIFF
--- a/lib/escher.js
+++ b/lib/escher.js
@@ -11,11 +11,20 @@ var Escher = function(configToMerge) {
     algoPrefix: 'ESR',
     vendorKey: 'ESCHER',
     hashAlgo: 'SHA256',
-    date: new Date(),
     credentialScope: 'escher_request',
     authHeaderName: 'X-Escher-Auth',
     dateHeaderName: 'X-Escher-Date',
-    clockSkew: 300
+    clockSkew: 300,
+    get date() {
+      return this._date || new Date();
+    },
+    set date(date) {
+      if (!(configToMerge.date instanceof Date)) {
+        throw new Error('Date should be a JavaScript Date object');
+      }
+
+      this._date = date;
+    }
   }, configToMerge);
 
   // validate the configuration
@@ -29,10 +38,6 @@ var Escher = function(configToMerge) {
 
   if (typeof config.hashAlgo !== 'string' || ['SHA256', 'SHA512'].indexOf(config.hashAlgo) === -1) {
     throw new Error('Only SHA256 and SHA512 hash algorithms are allowed');
-  }
-
-  if (!(config.date instanceof Date)) {
-    throw new Error('Date should be a JavaScript Date object');
   }
 
   this._config = config;

--- a/lib/escher.js
+++ b/lib/escher.js
@@ -19,7 +19,7 @@ var Escher = function(configToMerge) {
       return this._date || new Date();
     },
     set date(date) {
-      if (!(configToMerge.date instanceof Date)) {
+      if (!(date instanceof Date)) {
         throw new Error('Date should be a JavaScript Date object');
       }
 


### PR DESCRIPTION
This change allows Escher to sign and validate signature against the current date, unless a date is provided explicitly to the constructor. The date is resolved when accessing the date property using an ES5 property getter. If a date is specified when creating the Escher object, the explicitly given date is saved in an internal config variable.

refs #5