### PR TITLE
Remove forced type check of request body

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 .lock-wscript
 
 .idea
+/package-lock.json

--- a/lib/escher.js
+++ b/lib/escher.js
@@ -138,8 +138,7 @@ Escher.prototype = {
     }
 
     var reqBody = (typeof body != 'undefined') ? body : request.body;
-    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1 &&
-      !(typeof reqBody === 'string' || reqBody instanceof Buffer)) {
+    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1) {
       throw new Error("The request body shouldn't be empty if the request method is POST");
     }
 

--- a/lib/escher.js
+++ b/lib/escher.js
@@ -138,7 +138,7 @@ Escher.prototype = {
     }
 
     var reqBody = (typeof body != 'undefined') ? body : request.body;
-    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1) {
+    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1 && !request.body) {
       throw new Error("The request body shouldn't be empty if the request method is POST");
     }
 

--- a/lib/escher.js
+++ b/lib/escher.js
@@ -138,7 +138,7 @@ Escher.prototype = {
     }
 
     var reqBody = (typeof body != 'undefined') ? body : request.body;
-    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1 && !request.body) {
+    if (['POST', 'PUT', 'PATCH'].indexOf(request.method) !== -1 && !reqBody) {
       throw new Error("The request body shouldn't be empty if the request method is POST");
     }
 


### PR DESCRIPTION
Escher is authentication framework, so it shouldn't make assumptions on the data type of the request body. This is especially clear when using alongside other request body parsing middleware in frameworks like express or koa.

Example:

```javascript
const bodyParser = require('body-parser'),
          Escher = require('escher-auth');

app.use(bodyParser.json());

// ... setup escher options

escher.authenticate(request, keyDB);
```

This throws an error

```console
Error: The request body shouldn't be empty if the request method is POST
```

However, the body is present, in the form of an object:

```JSON
{
    "body": {
        "customer_id": "00000000",
        "resource_id": null,
        "environment": "suite00.emarsys.net",
        "language": "en"
    }
}
```

---

This pull request changes the type check of req.body from a strict String or Buffer to a simple exists check:

```javascript
//Before
!(typeof reqBody === 'string' || reqBody instanceof Buffer)

// After
!request.body
```