### PR TITLE
INT-0070: Remove path platform dependency as it is unnecessary in recent node versions

### DIFF
--- a/lib/canonicalizer.js
+++ b/lib/canonicalizer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var path = require('path-platform').posix;
+var path = require('path').posix;
 var utils = require('./utils');
 
 var Canonicalizer = function(hashAlgo) {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "dateformat": "3.0.2",
     "is-number": "3.0.0",
-    "is-string": "1.0.4",
-    "path-platform": "0.11.15"
+    "is-string": "1.0.4"
   }
 }


### PR DESCRIPTION
path-platform (https://www.npmjs.com/package/path-platform) was a transitional package (for node versions < 0.12).